### PR TITLE
Fix redirect warnings in Google Search Console

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -21,6 +21,26 @@
 [build.processing.html]
   pretty_urls = true
 
+# Force HTTPS and canonical domain (non-www)
+[[redirects]]
+  from = "http://lanonasis.com/*"
+  to = "https://lanonasis.com/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "http://www.lanonasis.com/*"
+  to = "https://lanonasis.com/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "https://www.lanonasis.com/*"
+  to = "https://lanonasis.com/:splat"
+  status = 301
+  force = true
+
+# SPA fallback - must come after the canonical domain redirects
 [[redirects]]
   from = "/*"
   to = "/index.html"


### PR DESCRIPTION
Add 301 redirects to resolve Google Search Console "Page with redirect" warnings:
- Redirect http://lanonasis.com/* to https://lanonasis.com/:splat
- Redirect http://www.lanonasis.com/* to https://lanonasis.com/:splat
- Redirect https://www.lanonasis.com/* to https://lanonasis.com/:splat

These redirects ensure all traffic is properly directed to the canonical HTTPS non-www domain, preventing 403 errors and eliminating redirect warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated domain configuration to enforce HTTPS and canonical domain handling.
  * Configured single-page application routing for improved navigation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->